### PR TITLE
Dont use a hardcoded printer model when printing using the builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Full example with 3 lines:
      .text("This is a example", {})
      .text("Say, good bye!", {})
      .cutPaper()
-     .print(portName, function(err, result){
+     .print(deviceName, printerName, function(err, result){
        if (err) return console.log(err);
        // code here...
      });
@@ -104,7 +104,7 @@ Example with shared style:
      .text("I'm center too", myStyle)
      .text("all is center", myStyle)
      .cutPaper()
-     .print(portName, function(err, result){
+     .print(deviceName, printerName, function(err, result){
        if (err) return console.log(err);
        // code here...
      });
@@ -146,7 +146,7 @@ Cut the paper.
 
 Finally for print, just call ``print`` command.
 ```
-builder.print(portName, function(error, result){
+builder.print(deviceName, printerName, function(error, result){
   if (error) {
     console.error(error);
   } else {

--- a/src/android/EPOSPrinter.java
+++ b/src/android/EPOSPrinter.java
@@ -53,7 +53,8 @@ public class EPOSPrinter extends CordovaPlugin {
         if (action.equals("print")) {
             JSONArray params = args.getJSONArray(0);
             String port = args.getString(1);
-            this.printFromBuilder(port, params);
+	    String model = args.getString(2);
+            this.printFromBuilder(port, model, params);
             return true;
         }
 
@@ -208,7 +209,7 @@ public class EPOSPrinter extends CordovaPlugin {
         }
     }
 
-    private void printFromBuilder(final String port, JSONArray params) throws JSONException  {
+    private void printFromBuilder(final String port, final String model, JSONArray params) throws JSONException  {
 
         Print printer = null;
         int[] status = new int[1];
@@ -220,7 +221,7 @@ public class EPOSPrinter extends CordovaPlugin {
 
 
             //Initialize a Builder class instance
-            Builder builder = new Builder("TM-T88V", Builder.MODEL_ANK);
+            Builder builder = new Builder(model, Builder.MODEL_ANK);
 
             pushCommandsToBuilder(builder, params);
 

--- a/www/EPOSPrinter.js
+++ b/www/EPOSPrinter.js
@@ -96,8 +96,8 @@ function Builder(options){
       return this;
     }
 
-    this.print = function(port, callback){
-        var args = [this.commands, port];
+    this.print = function(port, model, callback){
+        var args = [this.commands, port, model];
 
         exec(function (result) {
             callback(null, result)


### PR DESCRIPTION
Using the hardcoded printer model "TM-T88V" when creating a Builder instance will cause Exceptions and printing artifacts if the printer is not a TM-T88V. This PR creates a new argument when calling print() on the builder. This PR was tested using a TM-U220.